### PR TITLE
Add SEO meta tags

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,9 @@
 <svelte:head>
   <title>kaio magalhaes | blog</title>
 
+  <meta name="description" content="A blog about (mostly) computery things" />
+  <link rel="canonical" href="https://www.kaiomagalhaes.com/" />
+
   <meta property="og:url" content="https://www.kaiomagalhaes.com" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="kaiomagalhaes" />

--- a/src/routes/about/+page.svx
+++ b/src/routes/about/+page.svx
@@ -4,8 +4,14 @@ tagline: 'obligatory self-describing blurb'
 ---
 
 <script>
-	import WaveText from "$lib/components/WaveText.svelte";
+        import WaveText from "$lib/components/WaveText.svelte";
 </script>
+
+<svelte:head>
+  <title>kaio magalhaes | about</title>
+  <meta name="description" content="obligatory self-describing blurb" />
+  <link rel="canonical" href="https://www.kaiomagalhaes.com/about" />
+</svelte:head>
 
 <h1 class="text-center text-secondary text-base">
   obligatory self-describing blurb

--- a/src/routes/blog/[post]/+page.svelte
+++ b/src/routes/blog/[post]/+page.svelte
@@ -1,27 +1,31 @@
 <script lang="ts">
   import type { PageData } from './$types';
   import { formatTitle, formatPublishDate } from '$lib/format';
+  import BlogLayout from '$lib/components/BlogLayout.svelte';
   export let data: PageData;
   let title = formatTitle(data.metadata.title);
   let published = formatPublishDate(data.metadata.published);
+  let canonical = `https://www.kaiomagalhaes.com/blog/${data.metadata.slug}`;
 </script>
 
-<span class="text-secondary font-cursive relative -top-8 md:inline hidden">
-  {published}
-</span>
+<BlogLayout title={data.metadata.title} published={data.metadata.published} canonical={canonical}>
+  <span class="text-secondary font-cursive relative -top-8 md:inline hidden">
+    {published}
+  </span>
 
-<h1 class="text-center">{title}</h1>
+  <h1 class="text-center">{title}</h1>
 
-<span class="text-secondary font-cursive relative block text-center text-sm md:hidden -mb-2 -mt-1">
-  {published}
-</span>
+  <span class="text-secondary font-cursive relative block text-center text-sm md:hidden -mb-2 -mt-1">
+    {published}
+  </span>
 
-<hr />
+  <hr />
 
-<svelte:component this={data.component} {published} />
+  <svelte:component this={data.component} {published} />
 
-<hr />
+  <hr />
 
-<div class="text-center text-link pt-8 pb-12">
-  <a href="/"> read some more </a>
-</div>
+  <div class="text-center text-link pt-8 pb-12">
+    <a href="/"> read some more </a>
+  </div>
+</BlogLayout>

--- a/src/routes/blog/_posts/2025-05-16-choosing-the-right-software-in-an-era-of-vaporware.svx
+++ b/src/routes/blog/_posts/2025-05-16-choosing-the-right-software-in-an-era-of-vaporware.svx
@@ -1,0 +1,45 @@
+---
+title: 'Choosing the Right Software in an Era of Vaporware'
+---
+
+Working in the custom-software industry means that, more often than not, I’m comparing what **we** can achieve for our customers with what’s already on the market, neatly packaged and sold as SaaS. That exercise usually involves digging through documentation, marketing pages, slick websites, and a never-ending stream of **“we-can-do-everything”** sales pitches that too often turn into unfulfilled promises. There’s a persistent disconnect between product and sales: sales swears everything is possible but there’s always a * lurking somewhere.
+
+Let’s get real.
+
+---
+
+## The StorageInc * - A Case Study
+
+A few years ago, I watched a company, let’s call them **Acme**, sign a contract with a file-storage vendor we’ll dub **StorageInc**. Acme needed to stash terabytes of files and make them searchable so users could review documents and use them as learning materials. StorageInc’s pitch sounded perfect: “Just store your files with us, hit the API with a search term, and boom! instant results.” Simpler than anything else I could find at the time.
+
+Search was mission-critical for Acme. With all the security layers and a long list of other must-haves, they inked a multimillion-dollar deal. Only afterward did I discover the ominous *: **the search indexed only the first 10 pages** of any file. Acme had documents hundreds of pages long massive problem.
+
+Then came user mapping. Because of how billing worked, Acme couldn’t do a 1-to-1 mapping between their users and StorageInc’s authorization system. Another fact learned too late.
+
+The result? A legal battle to break the contract because, suddenly, building the entire service in-house was cheaper than using StorageInc.
+
+---
+
+## Vaporware, Super-Charged by AI
+
+That wasn’t the last time I saw a client blindsided by half-baked features. And with AI hype everywhere, I’m afraid we’ll see a lot more of it. Every new AI-powered product demo promises the moon, while under the hood the functionality is half-built, misunderstood by developers, or riddled with security gaps.
+
+We’ve always had vaporware, now it just feels like **most** of what’s out there is vaporware.
+
+We are shipping features faster than ever, but it doesn't not mean we are keeping up with the product quality. 
+
+---
+
+## Before You Swipe Your Credit Card
+
+These days it’s easier than ever to sell shiny features behind a polished UI that don’t actually exist. So before you commit:
+
+1. **Understand the app’s true proposal.**  
+2. **Review the full feature set and the fine print.**  
+3. **Talk to a human.** Ask direct yes/no questions; don’t accept “it depends.”  
+4. **Run a trial, if possible.**  
+5. **Never** commit to more than a few hundred dollars without serious due diligence.
+
+---
+
+Choosing the right software in an era of vaporware is less about dazzling demos and more about ruthless verification. Keep your guard up, dig for the *, and don’t let the promise of “AI magic” cloud your judgment.

--- a/src/routes/interests/+page.svx
+++ b/src/routes/interests/+page.svx
@@ -4,8 +4,14 @@ tagline: 'things I like and you might too'
 ---
 
 <script>
-	import WaveText from "$lib/components/WaveText.svelte";
+        import WaveText from "$lib/components/WaveText.svelte";
 </script>
+
+<svelte:head>
+  <title>kaio magalhaes | interests</title>
+  <meta name="description" content="things I like and you might too" />
+  <link rel="canonical" href="https://www.kaiomagalhaes.com/interests" />
+</svelte:head>
 
 <h1 class="text-secondary text-base">
   things I like and you might too

--- a/src/routes/notes.svx
+++ b/src/routes/notes.svx
@@ -2,6 +2,12 @@
 title: 'notes'
 ---
 
+<svelte:head>
+  <title>kaio magalhaes | notes</title>
+  <meta name="description" content="Random thoughts, ideas and links" />
+  <link rel="canonical" href="https://www.kaiomagalhaes.com/notes" />
+</svelte:head>
+
 <h1 class="text-base text-secondary">
   random thoughts, ideas, links to conversations, music, etc.
   <br/>

--- a/src/routes/styleguide.svx
+++ b/src/routes/styleguide.svx
@@ -2,6 +2,12 @@
 title: 'styleguide'
 ---
 
+<svelte:head>
+  <title>kaio magalhaes | styleguide</title>
+  <meta name="description" content="Styleguide examples" />
+  <link rel="canonical" href="https://www.kaiomagalhaes.com/styleguide" />
+</svelte:head>
+
 # Styleguide
 
 ---


### PR DESCRIPTION
## Summary
- add meta description and canonical link to main blog page
- add SEO meta tags to the About, Interests, Notes and Styleguide pages
- include BlogLayout on blog post pages so each article has canonical URLs

## Testing
- `npm test` *(fails: playwright not found)*